### PR TITLE
Added scrolltable classes to bottom tables of main three pages

### DIFF
--- a/client/src/app/DiseaseBurdenPage.vue
+++ b/client/src/app/DiseaseBurdenPage.vue
@@ -120,7 +120,7 @@ Last update: 2018sep22
 
 
 
-      <table class="table table-bordered table-hover table-striped" style="width: 100%; margin-top: 10px;">
+      <table class="table table-bordered table-hover table-striped scrolltable" style="width: 100%; margin-top: 10px;">
         <thead>
           <tr>
             <th style="text-align:center">

--- a/client/src/app/HealthPackagesPage.vue
+++ b/client/src/app/HealthPackagesPage.vue
@@ -105,7 +105,7 @@ Last update: 2018-05-29
       </div>
 
 
-      <table class="table table-bordered table-hover table-striped" style="width: 100%; margin-top: 10px;">
+      <table class="table table-bordered table-hover table-striped scrolltable" style="width: 100%; margin-top: 10px;">
         <thead>
         <tr>
           <th style="text-align:center">Active</th>

--- a/client/src/app/InterventionsPage.vue
+++ b/client/src/app/InterventionsPage.vue
@@ -109,7 +109,7 @@ Last update: 2018sep22
 
     <div class="PageSection" v-if="activeIntervSet.intervset != undefined">
 
-      <table class="table table-bordered table-hover table-striped" style="width: auto; margin-top: 10px;">
+      <table class="table table-bordered table-hover table-striped scrolltable" style="width: auto; margin-top: 10px;">
         <thead>
         <tr>
           <th>Active</th>


### PR DESCRIPTION
This PR uses the new `scrolltable` class to make the bottom tables in the "Disease Burden", "Interventions", and "Health Packages" pages scrollable, with the headers staying fixed.